### PR TITLE
Feature-ethereum

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Grunt will automatically lint your code to the style used in this project, and w
 - [Simon Grondin](https://github.com/SGrondin) (DNS-based censorship circumvention)
 - [Matthieu Rakotojaona](https://otokar.looc2011.eu/) (DANE/TLSA contributions and misc. fixes)
 - [TJ Fontaine](https://github.com/tjfontaine) (For `native-dns`, `native-dns-packet` modules and related projects)
+- [Cayman Nava](https://github.com/WeMeetAgain) (Ethereum support)
 - *Your name & link of choice here!*
 
 ## Release History<a name="Release"/>

--- a/src/lib/config.coffee
+++ b/src/lib/config.coffee
@@ -20,6 +20,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 - Namecoin
     - Non-Windows: ~/.namecoin/namecoin.conf
     - Windows: %APPDATA%\Namecoin\namecoin.conf
+- Ethereum
+    - local in ~/.ethereum/conf.ini -- not used
 
 All parametrs can be overwritten using command line args and/or environment variables.
 ###
@@ -69,6 +71,10 @@ module.exports = (dnschain) ->
             rpc_password: undefined
             httpd_endpoint: undefined
     
+    ethDefs =
+        rpcport: 8081 # will certainly change
+        rpcconnect: '127.0.0.1'
+
     fileFormatOpts =
         comments: ['#', ';']
         sections: true
@@ -118,10 +124,14 @@ module.exports = (dnschain) ->
     else
         # TODO: this!
 
+    # ethereum
+    eth = (new nconf.Provider()).argv().env()
+
     stores =
         dnschain: nconf.defaults defaults
         nmc: nmc.defaults nmcDefs
         bdns: bdns.defaults bdnsDefs
+        eth: eth.defaults ethDefs
 
     config =
         get: (key, store="dnschain") -> stores[store].get key
@@ -133,3 +143,6 @@ module.exports = (dnschain) ->
         bdns:
             get: (key)-> config.get key, 'bdns'
             set: (key, value)-> config.set key, value, 'bdns'
+        eth:
+            get: (key)-> config.get key, 'eth'
+            set: (key, value)-> config.set key, value, 'eth'

--- a/src/lib/config.coffee
+++ b/src/lib/config.coffee
@@ -72,7 +72,7 @@ module.exports = (dnschain) ->
             httpd_endpoint: undefined
     
     ethDefs =
-        rpcport: 8081 # will certainly change
+        rpcport: 8080 # will certainly change
         rpcconnect: '127.0.0.1'
 
     fileFormatOpts =

--- a/src/lib/config.coffee
+++ b/src/lib/config.coffee
@@ -21,7 +21,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     - Non-Windows: ~/.namecoin/namecoin.conf
     - Windows: %APPDATA%\Namecoin\namecoin.conf
 - Ethereum
-    - local in ~/.ethereum/conf.ini -- not used
+    - local in ~/.ethereum/conf.ini (or ~/.mist/conf.ini)
 
 All parametrs can be overwritten using command line args and/or environment variables.
 ###
@@ -126,6 +126,13 @@ module.exports = (dnschain) ->
 
     # ethereum
     eth = (new nconf.Provider()).argv().env()
+    ethConf = _.find _.filter([
+        [process.env.HOME,'.ethereum','conf.ini'],
+        [process.env.HOME,'.mist','conf.ini']]
+    , (x) -> !!x[0])
+    , (x) -> fs.existsSync path.join x...
+
+    eth.file('user', {file: path.join(ethConf...), format: nconf.formats.ini}) if ethConf
 
     stores =
         dnschain: nconf.defaults defaults

--- a/src/lib/dns.coffee
+++ b/src/lib/dns.coffee
@@ -112,14 +112,18 @@ module.exports = (dnschain) ->
             ttl = Math.floor(Math.random() * 3600) + 30 # TODO: pick an appropriate TTL value!
             @log.debug "received question", q
 
-            if /\.(bit|p2p)$/.test q.name
+            if /\.(bit|p2p|eth)$/.test q.name
                 if S(q.name).endsWith '.bit'
                     nmcDomain = @namecoinizeDomain q.name
                     resolver = 'nmc'
-                else
+                else if S(q.name).endsWith '.p2p'
                     # TODO: bdns-izeDomain
                     nmcDomain = S(q.name).chompRight('.p2p').s
                     resolver = 'bdns'
+                else
+                    # TODO: eth-izeDomain
+                    nmcDomain = S(q.name).chompRight('.eth').s
+                    resolver = 'eth'
                 
                 @log.debug gLineInfo("resolving via #{resolver}..."), {nmcDomain:nmcDomain, q:q}
 

--- a/src/lib/dnschain.coffee
+++ b/src/lib/dnschain.coffee
@@ -58,6 +58,7 @@ exports.createServer = (a...) -> new DNSChain a...
 
 NMCPeer = require('./nmc')(exports)
 BDNSPeer = require('./bdns')(exports)
+ETHPeer = require('./eth')(exports)
 DNSServer = require('./dns')(exports)
 HTTPServer = require('./http')(exports)
 
@@ -67,6 +68,7 @@ exports.DNSChain = class DNSChain
         try
             @nmc = new NMCPeer @
             @bdns = new BDNSPeer @
+            @eth = new ETHPeer @
             @dns = new DNSServer @
             @http = new HTTPServer @
             @log.info "DNSChain started and advertising on: #{gConf.get 'dns:externalIP'}"

--- a/src/lib/eth.coffee
+++ b/src/lib/eth.coffee
@@ -48,8 +48,8 @@ module.exports = (dnschain) ->
                 conn.handleMessage {
                     id: conn.latestId
                     error: e}
-            conn.conn.on 'error', err
-            conn.conn.on 'close', (err.bind null,'ECONNCLOSED')
+            conn.on 'error', err
+            conn.on 'close', (err.bind null,'ECONNCLOSED')
             conn.call 'EthereumApi.GetStorageAt', path_args, cb
 
         # TODO: make this cleaner. this is kinda ugly.

--- a/src/lib/eth.coffee
+++ b/src/lib/eth.coffee
@@ -46,5 +46,5 @@ module.exports = (dnschain) ->
             @peer.call 'EthereumApi.GetStorageAt', path_args, cb
 
         # TODO: make this cleaner. this is kinda ugly.
-        toJSONstr: (json) -> json
-        toJSONobj: (json) -> JSON.parse json
+        toJSONstr: (json) -> JSON.parse(json).result?.value
+        toJSONobj: (json) -> JSON.parse JSON.parse(json).result?.value

--- a/src/lib/eth.coffee
+++ b/src/lib/eth.coffee
@@ -37,7 +37,7 @@ module.exports = (dnschain) ->
             path_args = path.split '/'
             if path_args.length is 1
                 path_args = [{
-                    address: ''
+                    address: 'DnsReg'
                     key: path_args[0]}]
             else
                 path_args = [{

--- a/src/lib/eth.coffee
+++ b/src/lib/eth.coffee
@@ -26,8 +26,6 @@ module.exports = (dnschain) ->
             params = ["rpcport", "rpcconnect"].map (x)-> gConf.eth.get x
             @peer = rpc.Client.$create(params...).connectSocket(->) or gErr "rpc create"
 
-            # TODO: $create doesn't actually connect. you need to open a raw socket
-            #       or an http socket and see if that works before declaring it works
             @log.info "rpc to ethereum on: %s:%d", params[1], params[0]
 
         shutdown: ->

--- a/src/lib/eth.coffee
+++ b/src/lib/eth.coffee
@@ -47,4 +47,4 @@ module.exports = (dnschain) ->
 
         # TODO: make this cleaner. this is kinda ugly.
         toJSONstr: (json) -> json
-        toJSONobj: (json) -> JSON.parse json.value
+        toJSONobj: (json) -> JSON.parse json

--- a/src/lib/eth.coffee
+++ b/src/lib/eth.coffee
@@ -1,0 +1,52 @@
+###
+
+dnschain
+http://dnschain.net
+
+Copyright (c) 2014 okTurtles Foundation
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+###
+
+module.exports = (dnschain) ->
+    # expose these into our namespace
+    for k of dnschain.globals
+        eval "var #{k} = dnschain.globals.#{k};"
+
+    class ETHPeer
+        constructor: (@dnschain) ->
+            # @log = @dnschain.log.child server: "ETH"
+            @log = gNewLogger 'ETH'
+            @log.debug "Loading ETHPeer..."
+            
+            # we want them in this exact order:
+            params = ["rpcport", "rpcconnect"].map (x)-> gConf.eth.get x
+            @peer = rpc.Client.$create(params...).connectSocket(->) or gErr "rpc create"
+
+            # TODO: $create doesn't actually connect. you need to open a raw socket
+            #       or an http socket and see if that works before declaring it works
+            @log.info "rpc to ethereum on: %s:%d", params[1], params[0]
+
+        shutdown: ->
+            @log.debug 'shutting down!'
+            # @peer.end() # TODO: fix this!
+
+        resolve: (path, cb) ->
+            @log.debug gLineInfo('eth resolve'), {path:path}
+            path_args = path.split '/'
+            if path_args.length is 1
+                path_args = [{
+                    address: ''
+                    key: path_args[0]}]
+            else
+                path_args = [{
+                    address: path_args[0]
+                    key: path_args[1..].join '/'}]
+            @peer.call 'EthereumApi.GetStorageAt', path_args, cb
+
+        # TODO: make this cleaner. this is kinda ugly.
+        toJSONstr: (json) -> json
+        toJSONobj: (json) -> JSON.parse json.value

--- a/src/lib/http.coffee
+++ b/src/lib/http.coffee
@@ -54,6 +54,7 @@ module.exports = (dnschain) ->
             resolver = switch req.headers.host
                 when 'namecoin.dns' then 'nmc'
                 when 'bitshares.dns' then 'bdns'
+                when 'ethereum.dns' then 'eth'
                 else
                     @log.warn gLineInfo "unknown host type: #{req.headers.host} -- defaulting to namecoin.dns!"
                     'nmc'


### PR DESCRIPTION
Adds rudimentary support for Ethereum blockchain lookups.
It currently assumes `ethereum`, the go client, is running, with JSON-RPC enabled. This is defaulted to port 8080 currently.

Querying the Ethereum chain requires two parameters, the address, and key. Address is the contract address to look up, and key is the storage slot within the contract to query. These parameters are currently deduced by using the root element of the URL path as the address, and the rest as the key.
ie: ethereum.dns/ADDRESS/KEY