### PR TITLE
Enable CORS headers for HTTP API

### DIFF
--- a/src/lib/http.coffee
+++ b/src/lib/http.coffee
@@ -25,6 +25,11 @@ module.exports = (dnschain) ->
             @rateLimiting = gConf.get 'rateLimiting:http'
             app = express()
 
+            app.use (req, res, next) =>
+              res.header "Access-Control-Allow-Origin", "*"
+              res.header "Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept"
+              next()
+
             # Openname spec defined here:
             # - https://github.com/okTurtles/openname-specifications/blob/resolvers/resolvers.md
             # - https://github.com/openname/openname-specifications/blob/master/resolvers.md

--- a/test/https.coffee
+++ b/test/https.coffee
@@ -66,6 +66,11 @@ describe 'https', ->
             console.info "Result: #{stdout}".bold
             stdout.should.containEql data
 
+    it 'should send proper cors headers', ->
+       getAsync("http://localhost:#{gConf.get 'http:port'}/v1/namecoin/key/d%2Fokturtles").then (res) ->
+            res.header['access-control-allow-headers'].should.equal 'Origin, X-Requested-With, Content-Type, Accept'
+            res.header['access-control-allow-origin'].should.equal '*'
+
     it 'should shutdown successfully', ->
         server.shutdown() # returns a promise. Mocha should handle that properly
 


### PR DESCRIPTION
Setting the Cross-Origin Resource Sharing (CORS) headers in a global express middleware.
This allows pure client side JS applications to retrieve data from the public REST API. (api.dnschain.net) 

Please note that I am very new to the DNSchain code, looking forward to your feedback :) 