### PR TITLE
update travis.yml to use new container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ node_js:
   - iojs
 services:
   - redis-server
+sudo: false
+addons: 
+  apt: 
+    packages:
+      - dnsutils
 install:
-  - sudo apt-get update -q
-  - sudo apt-get install dnsutils
   - npm install


### PR DESCRIPTION
Travis switched to a new container based infrastructure and afik is slowly asking projects to upgrade. 
Information about this can be found in the travis docs: [http://docs.travis-ci.com/user/migrating-from-legacy/](docs.travis-ci.com/user/migrating-from-legacy/).

Status: travis is happy with the updated yml but no speed improvement. :/
