### PR TITLE
added support for CORS HTTP headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ node_js:
   - "0.12"
   - "0.10"
   - iojs
+env:
+  - CXX=g++-4.8
 services:
   - redis-server
 sudo: false
 addons: 
   apt: 
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - dnsutils
+      - g++-4.8
 install:
   - npm install

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _Approximate chronological order._
 - [Konstantinos Lolos](https://www.linkedin.com/in/kostislolos) ([pydnschain](https://github.com/okTurtles/pydnschain) work)
 - [Anton Wilhelm](https://github.com/toenu23) (Support for [Nxt](http://nxt.org) cryptocurrency)
 - [Tim Uy](https://github.com/tofutim) (Ubuntu tutorial)
+- [Michael Bumann](https://twitter.com/bumi) (optional CORS support)
 - *Your name & link of choice here!*
 
 ## Release History

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bottleneck": "1.5.x",
     "event-stream": "3.2.2",
     "express": "4.11.2",
-    "hiredis": "0.4.0",
+    "hiredis": "~0.4.1",
     "json-rpc2": "0.8.1",
     "lodash": "3.1.0",
     "native-dns": "git+https://github.com/okTurtles/node-dns.git#08433ec98f517eed3c6d5e47bdf62603539cd402",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bottleneck": "1.5.x",
     "event-stream": "3.2.2",
     "express": "4.11.2",
-    "hiredis": "~0.4.1",
+    "hiredis": "0.4.1",
     "json-rpc2": "0.8.1",
     "lodash": "3.1.0",
     "native-dns": "git+https://github.com/okTurtles/node-dns.git#08433ec98f517eed3c6d5e47bdf62603539cd402",

--- a/src/lib/config.coffee
+++ b/src/lib/config.coffee
@@ -76,6 +76,7 @@ module.exports = (dnschain) ->
             internalTLSPort: 2500   # Not accessible from the internet, used internally only
             internalAdminPort: 3000 # Not accessible from the internet, used internally only
             host: '0.0.0.0' # what we bind to. 0.0.0.0 for the whole internet
+            cors: false
         redis:
             socket: '127.0.0.1:6379' # or UNIX domain socket path
             oldDNS:

--- a/src/lib/http.coffee
+++ b/src/lib/http.coffee
@@ -26,7 +26,7 @@ module.exports = (dnschain) ->
             app = express()
 
             if gConf.get('http:cors')
-              @log.warn "Enabling CORS HTTP headers"
+              @log.warn "CORS enabled! Accessing DNSChain from a webpage JS relies on X.509 and therefore does not preserve the security properties of Namecoin!".bold
               app.use (req, res, next) =>
                 res.header "Access-Control-Allow-Origin", "*"
                 res.header "Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept"

--- a/src/lib/http.coffee
+++ b/src/lib/http.coffee
@@ -25,6 +25,13 @@ module.exports = (dnschain) ->
             @rateLimiting = gConf.get 'rateLimiting:http'
             app = express()
 
+            if gConf.get('http:cors')
+              @log.warn "Enabling CORS HTTP headers"
+              app.use (req, res, next) =>
+                res.header "Access-Control-Allow-Origin", "*"
+                res.header "Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept"
+                next()
+            
             # Openname spec defined here:
             # - https://github.com/okTurtles/openname-specifications/blob/resolvers/resolvers.md
             # - https://github.com/openname/openname-specifications/blob/master/resolvers.md

--- a/test/https.coffee
+++ b/test/https.coffee
@@ -66,6 +66,12 @@ describe 'https', ->
             console.info "Result: #{stdout}".bold
             stdout.should.containEql data
 
+    it 'should disable CORS by default', ->
+        getAsync("http://localhost:#{gConf.get 'http:port'}/v1/namecoin/key/d%2Fokturtles").then (res) ->
+            assert.equal(gConf.get('http:cors'), false)
+            assert.equal(res.header['access-control-allow-headers'], undefined)
+            assert.equal(res.header['access-control-allow-origin'], undefined)
+
     it 'should shutdown successfully', ->
         server.shutdown() # returns a promise. Mocha should handle that properly
 


### PR DESCRIPTION
Sets the Cross-Origin Resource Sharing (CORS) headers in a global express middleware.
This option is configurable and **disabled** by default.

To enable CORS use the following config entry:

```
[http]
cors: true
```
-------
See #162 for original PR discussion about enabling CORS. This PR makes CORS configurable and disables CORS by default. 

I have a test that checks if CORS is disabled (having only the default configuration). But I am not sure how to change a global option on the fly within a test that affects the server bootup. - if needed. 
