### PR TITLE
getdns dns resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "bottleneck": "1.5.x",
     "event-stream": "3.2.2",
     "express": "4.11.2",
+    "getdns": "^0.3.1",
     "hiredis": "0.4.1",
     "json-rpc2": "0.8.1",
     "lodash": "3.1.0",
@@ -50,8 +51,8 @@
     "properties": "1.2.1",
     "redis": "0.12.x",
     "string": "2.0.1",
-    "winston": "0.8.0",
-    "superagent": "0.21.0"
+    "superagent": "0.21.0",
+    "winston": "0.8.0"
   },
   "devDependencies": {
     "coffee-script": "^1.8.0",

--- a/src/lib/config.coffee
+++ b/src/lib/config.coffee
@@ -63,7 +63,7 @@ module.exports = (dnschain) ->
             port: if amRoot then 53 else 5333
             host: '0.0.0.0' # what we bind to
             externalIP: gExternalIP() # Advertised IP for .dns metaTLD (ex: namecoin.dns)
-            oldDNSMethod: 'NATIVE_DNS' # see 'globals.coffee' for possible values
+            oldDNSMethod: 'GETDNS' # see 'globals.coffee' for possible values
             oldDNS:
                 address: '8.8.8.8' # Google (we recommend running PowerDNS yourself and sending it there)
                 port: 53

--- a/src/lib/globals.coffee
+++ b/src/lib/globals.coffee
@@ -56,7 +56,9 @@ module.exports = (dnschain) ->
         # For now they're supported but their use is DEPRECATED and they *WILL* be removed!
         oldDNS:
             # Recommended method
-            NATIVE_DNS: 0 # Use 'native-dns' module (current default). Hopefully merged into NodeJS in the future: https://github.com/joyent/node/issues/6864#issuecomment-32229852
+            GETDNS: 4 # Use 'getdns-node' module (current default).
+
+            NATIVE_DNS: 0 # Use 'native-dns' module. Hopefully merged into NodeJS in the future: https://github.com/joyent/node/issues/6864#issuecomment-32229852
 
             #                    !! WARNING !!
             # > ! USING 'NODE_DNS' IS __STRONGLY DISCOURAGED__   ! <


### PR DESCRIPTION
Implements #101

Creates a new `oldDNS` constant: `GETDNS`.
Sets `GETDNS` as the default `oldDNS` method in `config.coffee`
When `GETDNS` is set as the `oldDNS` method, `getdns` is used to fetch DNS data.

Implementation Notes:
- When we use `getdns`, we have to initialize a context, where certain configuration options are set. 
- This context must also be destroyed on shutdown.
- Because we are still relying on `native-dns` as a DNS server (ie, sending DNS packets using `native-dns-packet`), we must gently translate the output from `getdns` into a form that `native-dns-packet` wants
